### PR TITLE
Set three and cannon-es as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "Cody Persinger <codypersinger@gmail.com> (https://github.com/codynova)"
   ],
   "license": "MIT",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,13 +32,18 @@
     "tabWidth": 2,
     "printWidth": 110
   },
-  "dependencies": {
-    "cannon-es": "^0.15.0"
-  },
   "peerDependencies": {
+    "cannon-es": "^0.15.1",
+    "three": "^0.118.3",
     "typescript": ">=3.8"
   },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "cannon-es": "^0.15.1",
     "prettier": "^2.0.5",
     "pretty-quick": "^2.0.1",
     "rimraf": "^3.0.2",

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,18 @@ This is a debugger for use with [cannon-es](https://github.com/react-spring/cann
 **Note:** This debugger currently does not work with [use-cannon](https://github.com/react-spring/use-cannon).
 
 
+### Installation
+
+
+```
+yarn add cannon-es-debugger
+```
+
+Make sure you also have `three` and `cannon-es` as dependencies.
+
+```
+yarn add three cannon-es
+```
 
 ### Usage
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,10 +42,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-cannon-es@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/cannon-es/-/cannon-es-0.15.0.tgz#0a4c09aaf1acf3789c9813f98350177c5f193842"
-  integrity sha512-R14+lIWqBNAnNGP0DglQ5CUxb0GEYZdXvKbZFfBapOO3UzZ7wBEKb9Dkq1jI+4IHDnb/Oshfc6p6Jsb5fYFzyQ==
+cannon-es@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/cannon-es/-/cannon-es-0.15.1.tgz#c5185e7efc19ca8b3b494eccd257256425b1642f"
+  integrity sha512-NkrU8OkM5K4q7Ljj69nfwC5UmPuoiAga6v98Aus0QHTdgJFwBfPTDXRkc3qpGGOixdUisFzmJo0DpKWIi6N+4g==
 
 chalk@^2.4.2:
   version "2.4.2"


### PR DESCRIPTION
Let's set `cannon-es` and `three` as peerDependencies since they're actually required by this library.

This way we don't have to update the cannon-es version each time, since the user will handle the cannon-es version.

They're also set as devDependencies since they're needed to build the library.

Typescript is set as an optional peerDependency since the user may decide to not use it.

Also I've replaced `module` with `main` in the package.json since `dist/index.js` is not actually an es-module, rather a commonjs one.